### PR TITLE
fix: send customer info during checkout

### DIFF
--- a/public/checkout.html
+++ b/public/checkout.html
@@ -141,7 +141,13 @@ checkout.html — Página de Checkout Heladería Victoria
         const res = await fetch('/api/checkout', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ items })
+          body: JSON.stringify({
+            customer_name: name,
+            customer_email: email,
+            customer_address: address,
+            payment_method: payment,
+            items
+          })
         });
         const data = await res.json();
 


### PR DESCRIPTION
## Summary
- include customer details in checkout POST request so server accepts it

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c51e4c735c83269c0c03c733b6f999