### PR TITLE
fix: use numeric product ids for checkout

### DIFF
--- a/public/js/store.js
+++ b/public/js/store.js
@@ -96,7 +96,8 @@ function renderProducts(products) {
   products.forEach(product => {
     const productCard = document.createElement('div');
     productCard.className = 'product-card';
-    productCard.dataset.id = `producto-${product.id}`;
+    // Store the numeric ID to ensure backend compatibility during checkout
+    productCard.dataset.id = String(product.id);
     productCard.dataset.category = product.category_id;
     productCard.dataset.price = product.price;
     


### PR DESCRIPTION
## Summary
- ensure front-end product cards store numeric ids to match backend

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c521e7352c83268d77d81cc090af67