### PR TITLE
feat: allow admin to add new users

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -83,6 +83,9 @@
 
           <!-- ========== VISTA USUARIOS ========== -->
           <div id="view-usuarios" class="card-table admin-only" style="display:none;">
+            <div class="actions">
+              <button class="btn-soft" id="btn-add-user"><i class="fas fa-user-plus"></i> Agregar usuario</button>
+            </div>
             <table class="table">
               <thead><tr><th>ID</th><th>Nombre</th><th>Email</th><th>Teléfono</th><th>Rol</th><th></th></tr></thead>
               <tbody id="tbl-usuarios-body">

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -492,6 +492,55 @@ document.addEventListener('click', async e => {
 });
 
 // Funciones para manipular usuarios
+const btnAddUser = document.getElementById('btn-add-user');
+if (btnAddUser) {
+  btnAddUser.addEventListener('click', () => addUser());
+}
+
+async function addUser() {
+  const { token } = getAuth();
+
+  openModal(
+    'Agregar Usuario',
+    [
+      { name: 'name', label: 'Nombre', type: 'text', required: true },
+      { name: 'email', label: 'Email', type: 'email', required: true },
+      { name: 'password', label: 'Contraseña', type: 'password', required: true },
+      {
+        name: 'role',
+        label: 'Rol',
+        type: 'select',
+        value: 'customer',
+        options: [
+          { value: 'admin', text: 'Administrador' },
+          { value: 'customer', text: 'Cliente' }
+        ],
+        required: true
+      },
+      { name: 'phone', label: 'Teléfono', type: 'text' },
+      { name: 'address', label: 'Dirección', type: 'text' }
+    ],
+    async (data) => {
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify(data)
+      });
+
+      if (res.ok) {
+        alert('Usuario creado correctamente');
+        loadUsers();
+      } else {
+        const err = await res.json().catch(() => ({}));
+        alert(err.message || 'Error al crear el usuario');
+      }
+    }
+  );
+}
+
 async function editUser(userId) {
   const { token } = getAuth();
   


### PR DESCRIPTION
## Summary
- add an **Agregar usuario** button to admin users panel
- support creating client or admin accounts via modal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c526c15d3c832695e30da7cf575612