### PR TITLE
feat: admin can add products with images

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -95,6 +95,9 @@
 
           <!-- ========== VISTA PRODUCTOS ========== -->
           <div id="view-productos" class="card-table admin-only" style="display:none;">
+            <div class="actions">
+              <button class="btn-soft" id="btn-add-product"><i class="fas fa-ice-cream"></i> Agregar producto</button>
+            </div>
             <table class="table">
               <thead><tr><th>ID</th><th>Nombre</th><th>Precio</th><th>Stock</th><th>Activo</th><th></th></tr></thead>
               <tbody id="tbl-productos-body">


### PR DESCRIPTION
## Summary
- allow admins to add new products from dashboard
- support image uploads and category selection when creating a product
- extend modal utility to handle textarea and file inputs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c52a529ef08326b921c9c11c186fcc