### PR TITLE
feat: invoice after checkout

### DIFF
--- a/public/checkout.html
+++ b/public/checkout.html
@@ -153,6 +153,18 @@ checkout.html — Página de Checkout Heladería Victoria
 
         if (res.ok) {
           alert('✅ Pedido realizado con éxito. ¡Gracias por tu compra!');
+
+          // Guardar información de la orden para generar la factura
+          const orderData = {
+            orderId: data.order_id,
+            total: data.total,
+            customer: { name, email, address },
+            items: cart,
+            createdAt: new Date().toISOString()
+          };
+          localStorage.setItem('lastOrder', JSON.stringify(orderData));
+
+          // Limpiar carrito y redirigir a la factura
           localStorage.removeItem('heladeriaCart');
           window.location.href = '/factura.html';
         } else {

--- a/public/css/factura.css
+++ b/public/css/factura.css
@@ -1,0 +1,30 @@
+.invoice-container {
+  max-width: 800px;
+  margin: 2rem auto;
+  background: var(--color-light);
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.invoice-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.invoice-table th,
+.invoice-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+.invoice-total {
+  text-align: right;
+  font-weight: bold;
+  margin-top: 1rem;
+}
+
+#download-invoice {
+  margin-top: 1.5rem;
+}

--- a/public/factura.html
+++ b/public/factura.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Factura - Heladería Victoria</title>
+  <link rel="stylesheet" href="/css/global.css"/>
+  <link rel="stylesheet" href="/css/factura.css"/>
+  <!-- Librería para generar PDF -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+</head>
+<body>
+  <div id="header-placeholder"></div>
+  <main class="invoice-container">
+    <h2>Factura</h2>
+    <div id="invoice-meta"></div>
+    <section id="customer-info"></section>
+    <table class="invoice-table">
+      <thead>
+        <tr>
+          <th>Producto</th>
+          <th>Cantidad</th>
+          <th>Precio</th>
+          <th>Subtotal</th>
+        </tr>
+      </thead>
+      <tbody id="invoice-items"></tbody>
+    </table>
+    <div class="invoice-total">Total: <span id="invoice-total">Q0.00</span></div>
+    <button id="download-invoice" class="btn">Descargar Factura</button>
+  </main>
+  <div id="footer-placeholder"></div>
+  <script src="/js/global.js"></script>
+  <script src="/js/factura.js"></script>
+</body>
+</html>

--- a/public/js/factura.js
+++ b/public/js/factura.js
@@ -1,0 +1,58 @@
+// factura.js - renderiza la factura y permite descargarla en PDF
+
+document.addEventListener('DOMContentLoaded', () => {
+  const order = JSON.parse(localStorage.getItem('lastOrder') || 'null');
+  if (!order) {
+    document.querySelector('.invoice-container').innerHTML = '<p>No hay factura disponible.</p>';
+    return;
+  }
+
+  // Mostrar meta e información del cliente
+  const metaEl = document.getElementById('invoice-meta');
+  const customerEl = document.getElementById('customer-info');
+  metaEl.innerHTML = `<p><strong>Orden #</strong> ${order.orderId} - ${new Date(order.createdAt).toLocaleString()}</p>`;
+  customerEl.innerHTML = `
+    <p><strong>Nombre:</strong> ${order.customer.name}</p>
+    <p><strong>Email:</strong> ${order.customer.email}</p>
+    <p><strong>Dirección:</strong> ${order.customer.address}</p>
+  `;
+
+  // Renderizar items
+  const itemsBody = document.getElementById('invoice-items');
+  let total = 0;
+  order.items.forEach(it => {
+    const subtotal = it.price * it.quantity;
+    total += subtotal;
+    itemsBody.insertAdjacentHTML('beforeend', `
+      <tr>
+        <td>${it.name}</td>
+        <td>${it.quantity}</td>
+        <td>Q${it.price.toFixed(2)}</td>
+        <td>Q${subtotal.toFixed(2)}</td>
+      </tr>
+    `);
+  });
+  document.getElementById('invoice-total').textContent = `Q${total.toFixed(2)}`;
+
+  // Descargar factura
+  document.getElementById('download-invoice').addEventListener('click', () => {
+    if (window.jspdf && window.jspdf.jsPDF) {
+      const { jsPDF } = window.jspdf;
+      const doc = new jsPDF();
+      doc.text('Factura - Heladería Victoria', 10, 10);
+      doc.text(`Orden #: ${order.orderId}`, 10, 20);
+      doc.text(`Nombre: ${order.customer.name}`, 10, 30);
+      doc.text(`Email: ${order.customer.email}`, 10, 40);
+      let y = 50;
+      order.items.forEach(it => {
+        doc.text(`${it.name} x${it.quantity} - Q${(it.price * it.quantity).toFixed(2)}`, 10, y);
+        y += 10;
+      });
+      doc.text(`Total: Q${total.toFixed(2)}`, 10, y + 10);
+      doc.save(`factura_${order.orderId}.pdf`);
+    } else {
+      // Fallback al diálogo de impresión
+      window.print();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- store order data on checkout and redirect to invoice page
- add invoice page that renders purchase details and downloads PDF

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5305c8cc883268e3433e63ba8ba10