### PR TITLE
Add admin-only dashboard with charts and filters

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -29,6 +29,7 @@
           <!-- Secciones de administración -->
           <div class="admin-actions-section">
             <div class="menu-group admin-actions-legend">Acciones de administrador</div>
+            <a href="dashboard.html" class="admin-only"><i class="fas fa-chart-line"></i> Dashboard</a>
             <a href="#productos" class="admin-only"><i class="fas fa-ice-cream"></i> Productos</a>
             <a href="#usuarios" class="admin-only"><i class="fas fa-users"></i> Usuarios</a>
           </div>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>📊 Dashboard - Heladería Victoria</title>
+  <link rel="stylesheet" href="/css/global.css"/>
+  <link rel="stylesheet" href="/css/admin.css"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <div id="header-placeholder" aria-hidden="true"></div>
+  <main class="account-shell">
+    <div class="account-title">DASHBOARD</div>
+    <section class="panel">
+      <h2 class="section-title"><i class="fas fa-chart-line"></i> Estadísticas</h2>
+      <div class="divider"></div>
+      <div class="card">
+        <form id="filters" class="grid-2" style="margin-bottom:1rem;">
+          <div class="row"><label>Desde</label><input type="date" id="from" class="input"/></div>
+          <div class="row"><label>Hasta</label><input type="date" id="to" class="input"/></div>
+        </form>
+        <div class="stats grid-4" style="margin-bottom:1rem; text-align:center;">
+          <div><strong id="stat-users">0</strong><div>Usuarios</div></div>
+          <div><strong id="stat-products">0</strong><div>Productos</div></div>
+          <div><strong id="stat-orders">0</strong><div>Pedidos</div></div>
+          <div><strong id="stat-sales">Q0.00</strong><div>Ventas</div></div>
+        </div>
+        <canvas id="salesChart" height="120"></canvas>
+      </div>
+    </section>
+  </main>
+  <div id="footer-placeholder" aria-hidden="true"></div>
+  <script src="/js/global.js"></script>
+  <script src="/js/dashboard.js"></script>
+</body>
+</html>

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -853,7 +853,7 @@ document.getElementById('btn-logout').addEventListener('click', e => {
   // Ocultar elementos de administración si no es admin
   if (user.role !== 'admin') {
     // Quitar elementos del menú
-    const adminMenuItems = menu.querySelectorAll('a[href="#usuarios"], a[href="#productos"]');
+    const adminMenuItems = menu.querySelectorAll('a.admin-only');
     adminMenuItems.forEach(item => item.remove());
 
     // Quitar leyenda de administración

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,0 +1,59 @@
+const TOKEN_KEY = 'authToken';
+
+async function init() {
+  const user = await checkAuth();
+  if (!user || user.role !== 'admin') {
+    window.location.href = '/login.html';
+    return;
+  }
+
+  const token = localStorage.getItem(TOKEN_KEY);
+  const fromInput = document.getElementById('from');
+  const toInput = document.getElementById('to');
+
+  const today = new Date().toISOString().slice(0, 10);
+  const lastMonth = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  fromInput.value = lastMonth;
+  toInput.value = today;
+
+  const ctx = document.getElementById('salesChart').getContext('2d');
+  const chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [{
+        label: 'Ventas',
+        data: [],
+        borderColor: '#2563eb',
+        backgroundColor: 'rgba(37,99,235,0.1)',
+        tension: 0.1
+      }]
+    },
+    options: { responsive: true }
+  });
+
+  async function loadData() {
+    const params = new URLSearchParams({ from: fromInput.value, to: toInput.value });
+    const res = await fetch(`/api/admin/dashboard?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (res.ok) {
+      const data = await res.json();
+      document.getElementById('stat-users').textContent = data.users;
+      document.getElementById('stat-products').textContent = data.products;
+      document.getElementById('stat-orders').textContent = data.orders;
+      document.getElementById('stat-sales').textContent = `Q${Number(data.sales).toFixed(2)}`;
+
+      chart.data.labels = data.ordersDaily.map(o => o.date);
+      chart.data.datasets[0].data = data.ordersDaily.map(o => o.total_sales);
+      chart.update();
+    }
+  }
+
+  fromInput.addEventListener('change', loadData);
+  toInput.addEventListener('change', loadData);
+
+  await loadData();
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- create secure `/api/admin/dashboard` endpoint with aggregated stats for admin users
- add dashboard page with charts, filters, and stats for admins only
- show dashboard link in admin menu and hide admin-only links for non-admin users

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5375bfe4c8326879dc4f9e7efe9d6