### PR TITLE
feat: add dark theme toggle

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -117,7 +117,10 @@
 
           <!-- ========== VISTA CONFIGURACIÓN ========== -->
           <div id="view-config" class="card" style="display:none;">
-            <!-- Contenido de configuración aquí -->
+            <div class="row">
+              <label>Tema</label>
+              <button class="btn-soft" id="btn-toggle-theme"><i class="fas fa-moon"></i> Tema oscuro</button>
+            </div>
           </div>
         </div>
       </section>

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -27,6 +27,16 @@
   --container-max: 1200px;
 }
 
+/* Tema oscuro */
+body.dark-theme {
+  --color-bg: #1a1a1a;
+  --color-light: #2c2c2c;
+  --color-dark: #f5f5f5;
+  --color-secondary-bg: rgba(255,107,139,0.2);
+  --color-text-muted: #bbbbbb;
+  --color-text-light: #f5f5f5;
+}
+
 
 /* BASE */
 * {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -70,6 +70,25 @@ const viewMap = {
   '#config': { el: '#view-config', icon: 'fa-sliders', title: 'Configuración' },
 };
 
+let configInitialized = false;
+function initConfig() {
+  if (configInitialized) return;
+  configInitialized = true;
+  const btn = document.getElementById('btn-toggle-theme');
+  if (!btn) return;
+  const updateBtn = () => {
+    const theme = localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+    btn.innerHTML = theme === 'dark'
+      ? '<i class="fas fa-sun"></i> Tema claro'
+      : '<i class="fas fa-moon"></i> Tema oscuro';
+  };
+  updateBtn();
+  btn.addEventListener('click', () => {
+    window.toggleTheme && window.toggleTheme();
+    updateBtn();
+  });
+}
+
 function showView(hash) {
   const { user } = getAuth();
   const view = viewMap[hash] || viewMap['#perfil'];
@@ -102,6 +121,8 @@ function showView(hash) {
     loadProducts();
   } else if (hash === '#pedidos') {
     loadOrders();
+  } else if (hash === '#config') {
+    initConfig();
   }
 }
 

--- a/public/js/global.js
+++ b/public/js/global.js
@@ -16,9 +16,25 @@
   window.addEventListener("pageshow", (e) => { 
     if (e.persisted) window.scrollTo(0, 0); 
   });
-  window.addEventListener("beforeunload", () => { 
-    window.scrollTo(0, 0); 
+  window.addEventListener("beforeunload", () => {
+    window.scrollTo(0, 0);
   });
+
+  const THEME_KEY = 'theme';
+
+  function applyTheme(theme) {
+    document.body.classList.toggle('dark-theme', theme === 'dark');
+  }
+
+  function toggleTheme() {
+    const current = localStorage.getItem(THEME_KEY) === 'dark' ? 'dark' : 'light';
+    const next = current === 'dark' ? 'light' : 'dark';
+    localStorage.setItem(THEME_KEY, next);
+    applyTheme(next);
+    return next;
+  }
+
+  window.toggleTheme = toggleTheme;
 
 // --------------------------------------------------------------------------
 // Plantilla del Header con lógica de autenticación
@@ -148,16 +164,20 @@ const headerHTML = `
     // Hacer el header sticky/fixed
     applyHeaderStickyOnly();
 
+    // Aplicar tema almacenado
+    const savedTheme = localStorage.getItem(THEME_KEY) || 'light';
+    applyTheme(savedTheme);
+
     // Señal de que el layout está listo para otros scripts
     document.dispatchEvent(new CustomEvent("layout:ready"));
 
     // Forzar scroll al inicio tras la carga
     setTimeout(() => {
-      try { 
-        window.scrollTo({ top: 0, left: 0, behavior: "auto" }); 
+      try {
+        window.scrollTo({ top: 0, left: 0, behavior: "auto" });
       }
-      catch { 
-        window.scrollTo(0, 0); 
+      catch {
+        window.scrollTo(0, 0);
       }
     }, 20);
   });


### PR DESCRIPTION
## Summary
- allow switching between light and dark themes with a new Configuración toggle
- introduce dark theme variable overrides and persist selected theme

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c53a12dcac832698631d2257ecfe9e