### PR TITLE
fix: respect theme colors on store page

### DIFF
--- a/public/css/store.css
+++ b/public/css/store.css
@@ -24,7 +24,7 @@
   font-family: inherit;
   font-size: 0.9rem;
   transition: var(--transition);
-  background: white;
+  background: var(--color-light);
 }
 
 .store-search-form input:focus {
@@ -56,7 +56,7 @@ header {
   position: sticky;
   top: 0;
   z-index: 1000;
-  background: white;
+  background: var(--color-light);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
## Summary
- ensure store search input and header use theme variables

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c53bc1ff7483269eb44e9a1ad5fdaf