### PR TITLE
Handle missing DB SSL certificate gracefully

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,6 @@ DB_PORT=4000
 DB_USER=9fPFVz5f8RypaAun.root
 DB_PASSWORD=RhjlbnZE4akmMMZLr
 DB_NAME=heladeria_cdb
-# Ruta local al certificado CA para la conexión SSL
-DB_SSL_CA=/path/to/ca.pem
+# Ruta local al certificado CA para la conexión SSL (dejar vacío si no se usa SSL)
+DB_SSL_CA=
 

--- a/server.js
+++ b/server.js
@@ -39,9 +39,21 @@ const dbConfig = {
 };
 
 if (process.env.DB_SSL_CA) {
-  dbConfig.ssl = {
-    ca: fs.readFileSync(process.env.DB_SSL_CA)
-  };
+  try {
+    if (fs.existsSync(process.env.DB_SSL_CA)) {
+      dbConfig.ssl = {
+        ca: fs.readFileSync(process.env.DB_SSL_CA)
+      };
+    } else {
+      console.warn(
+        `Archivo de certificado no encontrado en ${process.env.DB_SSL_CA}. Continuando sin SSL.`
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `No se pudo cargar el certificado SSL: ${error.message}. Continuando sin SSL.`
+    );
+  }
 }
 
 const pool = mysql.createPool(dbConfig);


### PR DESCRIPTION
## Summary
- Avoid crash when `DB_SSL_CA` path is invalid or missing
- Document optional CA certificate path in `.env`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` *(fails: getaddrinfo ENOTFOUND gateway01-us-east-1.prod.aws.tidbcloud.com)*

------
https://chatgpt.com/codex/tasks/task_e_68c575160e288326833ba9b9fd9c8648