### PR TITLE
fix: update DB connection settings

### DIFF
--- a/.env
+++ b/.env
@@ -2,11 +2,11 @@
 PORT=3000
 
 # Configuración de la base de datos MySQL
-DB_HOST=gateway01-us-east-1.prod.aws.tidbcloud.com
+DB_HOST=gateway01.us-east-1.prod.aws.tidbcloud.com
 DB_PORT=4000
 DB_USER=9fPFVz5f8RypaAun.root
 DB_PASSWORD=RhjlbnZE4akmMMZLr
-DB_NAME=heladeria_cdb
+DB_NAME=heladeria_db
 # Ruta local al certificado CA para la conexión SSL (dejar vacío si no se usa SSL)
 DB_SSL_CA=
 

--- a/server.js
+++ b/server.js
@@ -32,27 +32,30 @@ const dbConfig = {
   port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 4000,
   user: process.env.DB_USER || '9fPFVz5f8RypaAun.root',
   password: process.env.DB_PASSWORD || 'RhjlbnZE4akmMMZLr',
-  database: process.env.DB_NAME || 'heladeria_cdb',
+  database: process.env.DB_NAME || 'heladeria_db',
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0,
-  charset: 'utf8mb4'
+  charset: 'utf8mb4',
+  // Habilitar SSL por defecto para conexiones seguras
+  ssl: { rejectUnauthorized: true }
 };
 
 if (process.env.DB_SSL_CA) {
   try {
     if (fs.existsSync(process.env.DB_SSL_CA)) {
       dbConfig.ssl = {
+        ...dbConfig.ssl,
         ca: fs.readFileSync(process.env.DB_SSL_CA)
       };
     } else {
       console.warn(
-        `Archivo de certificado no encontrado en ${process.env.DB_SSL_CA}. Continuando sin SSL.`
+        `Archivo de certificado no encontrado en ${process.env.DB_SSL_CA}. Continuando sin SSL personalizado.`
       );
     }
   } catch (error) {
     console.warn(
-      `No se pudo cargar el certificado SSL: ${error.message}. Continuando sin SSL.`
+      `No se pudo cargar el certificado SSL: ${error.message}. Continuando sin SSL personalizado.`
     );
   }
 }


### PR DESCRIPTION
## Summary
- point DB config to TiDB Cloud host and heladeria_db database
- enable SSL by default and support optional CA

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start` *(fails: Error de conexión a la base de datos)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ea756288326b754ce3e621364c7